### PR TITLE
Allow setting of $GITHUB_HOST environment variable in order to use self-hosted GitHub Enterprise Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ github_runner_java_image: compscidr/github-runner-android:latest | the java / an
 github_runner_non_java_image: myoung34/github-runner:latest | the non-java/android runner image
 github_runner_env_file: false           | env file for passing extra environment variables into the runner container
 github_runner_env_filename: ".env"      | the filename of the env file for passing extra environment variables into the container
+github_runner_github_host: "github.com" | The GITHUB_HOST used for registering the runner.
 
 Notes: the env file lets you do things like set site-specific credentials into the runner that can be built into the code
 at build time, for instance, Wi-Fi credentials that can be built into tests that are specific to the location of

--- a/roles/github_runner/defaults/main.yml
+++ b/roles/github_runner/defaults/main.yml
@@ -17,3 +17,5 @@ github_runner_env_file: false
 github_runner_env_filename: ".env"
 
 github_runner_adb_port: 5037
+
+github_runner_github_host: "github.com"

--- a/roles/github_runner/tasks/main.yml
+++ b/roles/github_runner/tasks/main.yml
@@ -25,10 +25,10 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
-      REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      REPO_URL: "https://{{ github_runner_github_host }}/{{ github_runner_repo }}"
       GITHUB_HOST: "{{ github_runner_github_host }}"
   when: (not github_runner_org) and github_runner_java and github_runner_java_mount_usb and (not github_runner_env_file)
 
@@ -50,10 +50,10 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
-      REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      REPO_URL: "https://{{ github_runner_github_host }}/{{ github_runner_repo }}"
       GITHUB_HOST: "{{ github_runner_github_host }}"
     env_file: "{{ github_runner_env_filename }}"
   when: (not github_runner_org) and github_runner_java and github_runner_java_mount_usb and github_runner_env_file
@@ -74,10 +74,10 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
-      REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      REPO_URL: "https://{{ github_runner_github_host }}/{{ github_runner_repo }}"
       GITHUB_HOST: "{{ github_runner_github_host }}"
   when: (not github_runner_org) and github_runner_java and (not github_runner_java_mount_usb) and (not github_runner_env_file)
 
@@ -97,10 +97,10 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
-      REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      REPO_URL: "https://{{ github_runner_github_host }}/{{ github_runner_repo }}"
       GITHUB_HOST: "{{ github_runner_github_host }}"
     env_file: "{{ github_runner_env_filename }}"
   when: (not github_runner_org) and github_runner_java and (not github_runner_java_mount_usb) and github_runner_env_file
@@ -123,7 +123,7 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       RUNNER_SCOPE: "org"
@@ -149,7 +149,7 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       RUNNER_SCOPE: "org"
@@ -174,7 +174,7 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       RUNNER_SCOPE: "org"
@@ -198,7 +198,7 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       RUNNER_SCOPE: "org"
@@ -220,10 +220,10 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
-      REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      REPO_URL: "https://{{ github_runner_github_host }}/{{ github_runner_repo }}"
       GITHUB_HOST: "{{ github_runner_github_host }}"
   when: (not github_runner_org) and (not github_runner_java) and (not github_runner_env_file)
 
@@ -240,10 +240,10 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
-      REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      REPO_URL: "https://{{ github_runner_github_host }}/{{ github_runner_repo }}"
       GITHUB_HOST: "{{ github_runner_github_host }}"
     env_file: "{{ github_runner_env_filename }}"
   when: (not github_runner_org) and (not github_runner_java) and github_runner_env_file
@@ -261,7 +261,7 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       RUNNER_SCOPE: "org"
       HOST_NAME: "{{ inventory_hostname }}"
@@ -282,7 +282,7 @@
     env:
       ACCESS_TOKEN: "{{ github_runner_personal_access_token }}"
       DISABLE_AUTO_UPDATE: "true"
-      RUNNER_NAME_PREFIX: github_runner_name
+      RUNNER_NAME_PREFIX: "{{ github_runner_name }}"
       LABELS: "{{ github_runner_labels }}"
       RUNNER_SCOPE: "org"
       HOST_NAME: "{{ inventory_hostname }}"

--- a/roles/github_runner/tasks/main.yml
+++ b/roles/github_runner/tasks/main.yml
@@ -29,6 +29,7 @@
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
   when: (not github_runner_org) and github_runner_java and github_runner_java_mount_usb and (not github_runner_env_file)
 
 - name: Deploy Github Java / Android Repository Runner with USB mount and env file
@@ -53,6 +54,7 @@
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
     env_file: "{{ github_runner_env_filename }}"
   when: (not github_runner_org) and github_runner_java and github_runner_java_mount_usb and github_runner_env_file
 
@@ -76,6 +78,7 @@
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
   when: (not github_runner_org) and github_runner_java and (not github_runner_java_mount_usb) and (not github_runner_env_file)
 
 - name: Deploy Github Java / Android Repository Runner without USB mount and env file
@@ -98,6 +101,7 @@
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
     env_file: "{{ github_runner_env_filename }}"
   when: (not github_runner_org) and github_runner_java and (not github_runner_java_mount_usb) and github_runner_env_file
 
@@ -124,6 +128,7 @@
       HOST_NAME: "{{ inventory_hostname }}"
       RUNNER_SCOPE: "org"
       ORG_NAME: "{{ github_runner_org_name }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
   when: github_runner_org and github_runner_java and github_runner_java_mount_usb and (not github_runner_env_file)
 
 - name: Deploy Github Java / Android Organization Runner with USB mount and env file
@@ -149,6 +154,7 @@
       HOST_NAME: "{{ inventory_hostname }}"
       RUNNER_SCOPE: "org"
       ORG_NAME: "{{ github_runner_org_name }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
     env_file: "{{ github_runner_env_filename }}"
   when: github_runner_org and github_runner_java and github_runner_java_mount_usb and github_runner_env_file
 
@@ -173,6 +179,7 @@
       HOST_NAME: "{{ inventory_hostname }}"
       RUNNER_SCOPE: "org"
       ORG_NAME: "{{ github_runner_org_name }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
   when: github_runner_org and github_runner_java and (not github_runner_java_mount_usb) and (not github_runner_env_file)
 
 - name: Deploy Github Java / Android Organization Runner without USB mount and env file
@@ -196,6 +203,7 @@
       HOST_NAME: "{{ inventory_hostname }}"
       RUNNER_SCOPE: "org"
       ORG_NAME: "{{ github_runner_org_name }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
     env_file: "{{ github_runner_env_filename }}"
   when: github_runner_org and github_runner_java and (not github_runner_java_mount_usb) and github_runner_env_file
 
@@ -216,6 +224,7 @@
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
   when: (not github_runner_org) and (not github_runner_java) and (not github_runner_env_file)
 
 - name: Deploy Github Repository Runner and env file
@@ -235,6 +244,7 @@
       LABELS: "{{ github_runner_labels }}"
       HOST_NAME: "{{ inventory_hostname }}"
       REPO_URL: "https://github.com/{{ github_runner_repo }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
     env_file: "{{ github_runner_env_filename }}"
   when: (not github_runner_org) and (not github_runner_java) and github_runner_env_file
 
@@ -256,6 +266,7 @@
       RUNNER_SCOPE: "org"
       HOST_NAME: "{{ inventory_hostname }}"
       ORG_NAME: "{{ github_runner_org_name }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
   when: github_runner_org and (not github_runner_java) and (not github_runner_env_file)
 
 - name: Deploy Github Organization Runner and env file
@@ -276,5 +287,6 @@
       RUNNER_SCOPE: "org"
       HOST_NAME: "{{ inventory_hostname }}"
       ORG_NAME: "{{ github_runner_org_name }}"
+      GITHUB_HOST: "{{ github_runner_github_host }}"
     env_file: "{{ github_runner_env_filename }}"
   when: github_runner_org and (not github_runner_java) and github_runner_env_file


### PR DESCRIPTION
Also set the RUNNER_PREFIX to `{{ github_runner_name }}` instead of literal string "github_runner_name".  