### PR TITLE
fix: bound container stop and raise Docker API timeout on deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.4] - 2026-08-10
+### Fixed
+- First playbook run no longer fails with `UnixHTTPConnectionPool ... Read timed out (read timeout=60)` when replacing an existing runner container. Stopping and removing a crash-looping or wedged runner can exceed the Docker SDK's 60s default client timeout; the daemon finished the removal in the background, which is why an immediate rerun succeeded.
+
+### Added
+- `github_runner_docker_timeout` (default `180`): Docker API client timeout for the deploy task.
+- `github_runner_stop_timeout` (default `10`): seconds docker waits after SIGTERM before SIGKILL when stopping the runner container.
+
 ## [0.1.3] - 2026-05-27
 ### Added
 - Added `github_runner_network_mode` variable (defaults to `default`) to control the runner container's Docker network mode. Set to `host` so the in-container `adb` client can reach an adb server running on the host at `127.0.0.1:5037`.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ github_runner_env_file                      | whether to use an env file for pas
 github_runner_env_filename                  | the filename of the env file for passing extra environment variables into the container (defaults to ".env")
 github_runner_github_host                   | The GITHUB_HOST used for registering the runner (defaults to "github.com")
 github_runner_persist_config                | whether to persist runner configuration across container restarts using a named volume (defaults to true)
+github_runner_stop_timeout                  | seconds docker waits after SIGTERM before SIGKILL when stopping the runner container, e.g. while replacing it on an image bump (defaults to 10)
+github_runner_docker_timeout                | Docker API client timeout in seconds for the deploy task; stopping and removing a crash-looping runner can exceed the SDK's 60s default (defaults to 180)
 
 Notes: the env file lets you do things like set site-specific credentials into the runner that can be built into the code
 at build time, for instance, Wi-Fi credentials that can be built into tests that are specific to the location of

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: "Installs github self hosted repo or org runners within a docker co
   can be a vanilla runner, or one with java / android installed."
 license_file: LICENSE
 readme: README.md
-version: 0.1.3
+version: 0.1.4
 repository: https://github.com/compscidr/ansible-github-runner
 tags:
     - github

--- a/roles/github_runner/defaults/main.yml
+++ b/roles/github_runner/defaults/main.yml
@@ -26,3 +26,12 @@ github_runner_network_mode: default
 github_runner_github_host: "github.com"
 
 github_runner_persist_config: true
+
+# Seconds docker waits after SIGTERM before SIGKILL when stopping the runner
+# container (e.g. while replacing it on an image bump).
+github_runner_stop_timeout: 10
+
+# Docker API client timeout for the deploy task. Stopping and removing a
+# crash-looping or wedged runner container can exceed the SDK's 60s default,
+# which fails the first playbook run and succeeds on the rerun.
+github_runner_docker_timeout: 180

--- a/roles/github_runner/tasks/main.yml
+++ b/roles/github_runner/tasks/main.yml
@@ -10,6 +10,14 @@
     device_cgroup_rules: "{{ ['c 189:* rmw'] if (github_runner_java and github_runner_java_mount_usb) else omit }}"
     volumes: "{{ runner_volumes }}"
     restart_policy: unless-stopped
+    # Replacing an existing container (image bump) stops and removes it first.
+    # A crash-looping or wedged runner can take well over the Docker SDK's
+    # 60s default read timeout to stop+remove, which fails the first run and
+    # then succeeds on the rerun (the daemon finishes the removal in the
+    # background). Bound the graceful stop and give the API client enough
+    # room to wait out a slow removal.
+    stop_timeout: "{{ github_runner_stop_timeout }}"
+    timeout: "{{ github_runner_docker_timeout }}"
     network_mode: "{{ github_runner_network_mode }}"
     ports: "{{ runner_ports }}"
     env: "{{ runner_env }}"


### PR DESCRIPTION
## Problem

First playbook run against a host with an existing (especially crash-looping) runner container fails:

```
Error removing container <id>: UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)
```

…and the immediate rerun succeeds. Replacing the container stops+removes the old one first; a crash-looping or wedged runner can take longer than the Docker SDK's 60s default client timeout to stop and remove. The timeout only kills the client's wait — the daemon finishes the removal in the background, which is why the second pass works.

## Fix

Two new role vars, applied to the `docker_container` deploy task:

- `github_runner_docker_timeout` (default **180**) → module `timeout`: gives the API client room to wait out a slow stop+remove.
- `github_runner_stop_timeout` (default **10**) → container `stop_timeout`: bounds the graceful SIGTERM window before SIGKILL, so replacement stays fast even when the runner process is wedged. Deliberately not `force_kill` — a deploy racing a running CI job still gets a few seconds of cleanup.

Also bumps the collection to 0.1.4 with CHANGELOG and README variable-table entries, per repo convention.

## Testing

- `ansible-lint` clean (production profile, 33 files).
- YAML parse validated on the changed role files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)